### PR TITLE
Add support for hostnames and convert code to ES2017

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ let freeportAsync = require("freeport-async");
 
 let portIn9000Range = await freeportAsync(9000);
 
+let portAvailableForAnyOrLocalhost = await freeportAsync(9000, {
+  hostnames: [null, "localhost"]
+});
+
 let isPort5000Available = await freeportAsync.availableAsync(5000);
 
 let listOf5ConsecutiveAvailablePorts = await freeportAsync.rangeAsync(5);

--- a/index.js
+++ b/index.js
@@ -1,36 +1,50 @@
-var net = require('net');
+const net = require("net");
 
-var DEFAULT_PORT_RANGE_START = 11000;
+const DEFAULT_PORT_RANGE_START = 11000;
 
-function testPortAsync(port) {
-  return new Promise(function (fulfill, reject) {
-    var server = net.createServer()
-    server.listen(port, function (err) {
-      server.once('close', function () {
+function testPortAsync(port, hostname) {
+  return new Promise(function(fulfill, reject) {
+    var server = net.createServer();
+    server.listen({ port: port, host: hostname }, function(err) {
+      server.once("close", function() {
         setTimeout(() => fulfill(true), 0);
       });
       server.close();
     });
-    server.on('error', function (err) {
+    server.on("error", function(err) {
       setTimeout(() => fulfill(false), 0);
     });
   });
 }
 
+async function availableAsync(port, options = {}) {
+  const hostnames =
+    options.hostnames && options.hostnames.length ? options.hostnames : [null];
+  for (const hostname of hostnames) {
+    if (!(await testPortAsync(port, hostname))) {
+      return false;
+    }
+  }
+  return true;
+}
 
-function freePortRangeAsync(rangeSize, rangeStart) {
+function freePortRangeAsync(rangeSize, rangeStart, options = {}) {
   rangeSize = rangeSize || 1;
-  return new Promise(function (fulfill, reject) {
+  return new Promise((fulfill, reject) => {
     var lowPort = rangeStart || DEFAULT_PORT_RANGE_START;
     var awaitables = [];
     for (var i = 0; i < rangeSize; i++) {
-      awaitables.push(testPortAsync(lowPort + i));
+      awaitables.push(availableAsync(lowPort + i, options));
     }
-    return Promise.all(awaitables).then(function (results) {
+    return Promise.all(awaitables).then(function(results) {
       var ports = [];
       for (var i = 0; i < results.length; i++) {
         if (!results[i]) {
-          return freePortRangeAsync(rangeSize, lowPort + rangeSize).then(fulfill, reject);
+          return freePortRangeAsync(
+            rangeSize,
+            lowPort + rangeSize,
+            options
+          ).then(fulfill, reject);
         }
         ports.push(lowPort + i);
       }
@@ -39,13 +53,12 @@ function freePortRangeAsync(rangeSize, rangeStart) {
   });
 }
 
-function freePortAsync(rangeStart) {
-  return freePortRangeAsync(1, rangeStart).then(function (result) {
-    return result[0];
-  });
+async function freePortAsync(rangeStart, options = {}) {
+  const result = await freePortRangeAsync(1, rangeStart, options);
+  return result[0];
 }
 
 module.exports = freePortAsync;
 
-module.exports.availableAsync = testPortAsync;
+module.exports.availableAsync = availableAsync;
 module.exports.rangeAsync = freePortRangeAsync;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.2",
   "description": "Uses mikeal's code to find an open port in a given range",
   "main": "index.js",
+  "engines": {
+    "node": ">=8"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
If a server was listening on localhost:port, freeportAsync was not previously able
to detect it, but reported the port as available.

To find a port free from servers running in either 0.0.0.0 (or :: for IPv6)
or localhost, you can use:
```
await freeportAsync(19000, {hostnames: [null, 'localhost']})) }
```
(`null` means unspecified hostname, which is the default for `Server.listen`.)

Note: This PR uses ES2017 async-await and therefore requires Node.js 8 or newer. We should bump the semver major version for this release.